### PR TITLE
docs: add more docs and examples

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -3,6 +3,13 @@
 # SPDX-License-Identifier: MIT
 
 # Used by "mix format"
+locals_without_parens = [
+  defconst: 2,
+  defonce: 2
+]
+
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  locals_without_parens: locals_without_parens,
+  export: [locals_without_parens: locals_without_parens]
 ]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ def deps do
 end
 ```
 
+Optionally add `:defconstant` to your `.formatter.exs` to have `defconst`
+formatted without parens:
+
+```
+[
+  import_deps: [
+    :defconstant,
+    ...
+  ],
+  ...
+]
+```
+
 ## Usage
 
 This library provides 2 macros:
@@ -28,6 +41,56 @@ This library provides 2 macros:
 
 Both helper macros allows defining only 0-ary functions (functions that take no
 arguments).
+
+For details see the full docs on [hexdocs.pm](https://hexdocs.pm/defconstant/Defconstant.html)
+
+### Example usage
+
+``` elixir
+defmodule Demo.MyConst do
+  import Defconstant
+
+  defconst the_answer do
+    42
+  end
+
+  # NOTE: For real code you'd use `:math.pi` instead
+  defconst pi do
+    3.14159
+  end
+
+  defonce calculated_at do
+    NaiveDateTime.utc_now()
+  end
+
+  def run_calulations(circumference) do
+    circle_radius = circumference / 2 * pi()
+    "radius is #{circle_radius} and was first calculated at #{inspect calculated_at()}"
+  end
+end
+```
+
+And the constants can be used from another module (e.g. `Demo.MyConst.the_answer()` will return `42`)
+
+## Why
+
+Elixir and Erlang/OTP don't have true constants. They do have module attributes,
+which are often used like constants, but module attributes can be modified so
+they aren't truly constants. For example:
+
+``` elixir
+defmodule ModuleAttributeDemo do
+  @pi 3.14159
+  def pi, do: @pi
+
+  @pi 33
+  def radius(circumference), do: circumference / 2 * @pi
+end
+```
+
+Calling `ModuleAttributeDemo.radius(5)` will use `33` as the value for `@pi`
+instead of `3.14159`. With `defconst` this can be avoided because you will
+receive a warning when re-defining a constant.
 
 ## License
 

--- a/lib/defconst.ex
+++ b/lib/defconst.ex
@@ -4,7 +4,7 @@
 
 defmodule Defconstant do
   @moduledoc """
-  Helper functions for definig constant values in your modules.
+  Helper functions for defining constant values in your modules.
 
   ## Usage
 
@@ -27,11 +27,23 @@ defmodule Defconstant do
   end
   ```
   """
+
   @doc """
   Defines function that will be evaulated once, *in compile time*, and will
   return computation result.
 
   Defined function can only be 0-ary.
+
+  Example:
+
+      defmodule MyConstants do
+        import Defconstant
+        defconst the_answer, do: 42
+
+        def my_func do
+          the_answer() * 2 # returns 84
+        end
+      end
   """
   defmacro defconst({name, _, args}, do: body) when is_atom(args) or args == [] do
     quote bind_quoted: [name: name, result: body] do


### PR DESCRIPTION
Adding basic docs to the main Readme makes it easier for someone to get started

Also add an example to the function doc and add a .formatter.exs configuration